### PR TITLE
适配多个搜索器时的答案匹配

### DIFF
--- a/cxapi/jobs/exam.py
+++ b/cxapi/jobs/exam.py
@@ -235,9 +235,6 @@ class ChapterExam:
                             question.answer = k
                             self.logger.debug(f"单选题命中 {k}={v} {log_suffix}")
                             return True
-                    else:
-                        self.logger.warning(f"单选题填充失败 {log_suffix}")
-                        return False
                 case QuestionType.判断题:
                     if re.search(r"(错|否|错误|false|×)", search_answer):
                         question.answer = "false"
@@ -247,9 +244,6 @@ class ChapterExam:
                         question.answer = "true"
                         self.logger.debug(f"判断题命中 false {log_suffix}")
                         return True
-                    else:
-                        self.logger.warning(f"判断题填充失败 {log_suffix}")
-                        return False
                 case QuestionType.多选题:
                     option_lst = []
                     if len(part_answer_lst := search_answer.split("#")) <= 1:
@@ -265,16 +259,18 @@ class ChapterExam:
                         question.answer = "".join(option_lst)
                         self.logger.debug(f"多选题最终选项 {question.answer}")
                         return True
-                    self.logger.warning(f"多选题填充失败 {log_suffix}")
-                    return False
-                case _:
-                    self.logger.warning(
-                        f"未实现的题目类型 {question.q_type.name}/{question.q_type.value} {log_suffix}"
-                    )
-                    return False
-        else:
-            self.logger.warning(f"题目匹配失败 {log_suffix}")
-            return False
+        match question.q_type:
+            case QuestionType.单选题:
+                self.logger.warning(f"单选题填充失败 {log_suffix}")
+            case QuestionType.判断题:
+                self.logger.warning(f"判断题填充失败 {log_suffix}")
+            case QuestionType.多选题:
+                self.logger.warning(f"多选题填充失败 {log_suffix}")
+            case _:
+                self.logger.warning(
+                    f"未实现的题目类型 {question.q_type.name}/{question.q_type.value} {log_suffix}"
+                )
+        return False
 
     def fill_and_commit(self, tui_ctx: Layout) -> None:
         "填充并提交试题 答题主逻辑"


### PR DESCRIPTION
相关issue: #15 

原先的逻辑:
- `for`遍历每个搜索结果
- 如果匹配则返回`True`,否则返回`False`
- 🐛但是这样会导致多个搜索器的时候,只要有一个错误答案就会直接返回`False`,不管后面是不是还有别的搜索器提供了正确答案

修改后的逻辑:
 - `for`遍历每个搜索结果
 - 如果匹配则返回`True`并且会破坏`for`语句,反之则没有任何动作.
 - 没有打破`for`语句则视为没有答案,进行判断问题类型添加日志,并且返回`False`