### PR TITLE
增加题库海、Muke、冷月搜索源 并且添加Json格式请求的自定义搜索源

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ Enncy 题库，使用前请注册并获取 Token 填写在配置文件中（第�
 
 获取 Token 方式见 [文档](https://cx.icodef.com/1-UserGuide/1-6-gettoken.html#%E8%8E%B7%E5%8F%96token)
 
+题库海 题库，使用前请注册并获取 Token 填写在配置文件中（第三方题库）
+
+通过此 [链接](https://afdian.net/a/jiaoyu666) 获取 Token
+
 ## 📖Usage & Demo
 
 **注：本项目并非小白向“开箱即用”类型，需要一定的计算机专业技术能力；如需使用自动答题功能，请确保您拥有准确无误的题库资源**

--- a/config.yml
+++ b/config.yml
@@ -81,21 +81,37 @@ searchers:
   #     # eg: Token: 'xxx'
   #   a_field: "$.data"  # 返回参数 使用 JSONPath 语法进行查询
   
+  # Json API 在线搜题
+  # - type: JsonApiSearcher
+  #   url: "http://10.50.9.10:8088/question/search"  # API URL 请进行替换
+  #   q_field: "question"  # 题目参数名称
+  #   o_field: null  # 选项参数名称 (可选)  填写为用`#`分隔数据, 用来进一步匹配答案 (格式：选项A#选项B#选项C) 不填为{"A":"xxx","B":"xxx","C":"xxx","D":"xxx"}
+  #   headers:  # 自定义请求头 (可选) 使用 yaml 的 k-v 语法填写
+  #     # eg: Authorization: 'xxx'
+  #   ext_params: # 自定义扩展请求参数 (可选) 使用 yaml 的 k-v 语法填写
+  #     # eg: Token: 'xxx'
+  #   a_field: "$.data"  # 返回参数 使用 JSONPath 语法进行查询
+  
   # 本地 sqlite 数据库搜索器
   # - type: sqliteSearcher
   #   file_path: "questions.db"  # 数据库文件路径
   #   table: "question"  # 表名
   #   req_field: "question"  # 请求字段
   #   rsp_field: "answer"  # 返回字段
-
+  
   # Enncy 题库搜索器，使用前请注册 https://tk.enncy.cn/
   # - type: enncySearcher
   #   token: "xxx"  # Enncy 题库 Token
-
+  
   # 网课小工具(Go题)题库搜索器，使用前请获取Token https://cx.icodef.com/1-UserGuide/1-6-gettoken.html#%E8%8E%B7%E5%8F%96token
   # - type: cxSearcher
   #   token: "xxx"  # 网课小工具(Go题)题库 Token
-
-  # 题库海搜索源， 暂时可不用token 如若搜索失败 http://a.tikuhai.com/#/ 注册
+  
+  # 题库海搜索源， 暂时可不用token 如若搜索失败 https://afdian.net/a/jiaoyu666 购买token
   # - type: TiKuHaiSearcher
   #   token: ""
+  # 冷月题库, 免费限制4秒一次请求
+  # - type: LyCk6Searcher
+  #   token: ""
+  # Muke题库
+  # - type: MukeSearcher

--- a/config.yml
+++ b/config.yml
@@ -95,3 +95,7 @@ searchers:
   # 网课小工具(Go题)题库搜索器，使用前请获取Token https://cx.icodef.com/1-UserGuide/1-6-gettoken.html#%E8%8E%B7%E5%8F%96token
   # - type: cxSearcher
   #   token: "xxx"  # 网课小工具(Go题)题库 Token
+
+  # 题库海搜索源， 暂时可不用token 如若搜索失败 http://a.tikuhai.com/#/ 注册
+  # - type: TiKuHaiSearcher
+  #   token: ""

--- a/resolver/question.py
+++ b/resolver/question.py
@@ -25,8 +25,9 @@ from cxapi.schema import QuestionModel, QuestionsExportSchema, QuestionsExportTy
 from logger import Logger
 
 from .searcher import MultiSearcherWraper, SearcherResp
+
 from .searcher.json import JsonFileSearcher
-from .searcher.restapi import CxSearcher, EnncySearcher, RestApiSearcher
+from .searcher.restapi import CxSearcher, EnncySearcher, RestApiSearcher, TiKuHaiSearcher
 from .searcher.sqlite import SqliteSearcher
 
 # 所有的搜索器类
@@ -36,6 +37,7 @@ SEARCHERS = {
     "EnncySearcher": EnncySearcher,
     "RestApiSearcher": RestApiSearcher,
     "SqliteSearcher": SqliteSearcher,
+    "TiKuHaiSearcher": TiKuHaiSearcher,
 }
 
 
@@ -61,9 +63,9 @@ def load_searcher() -> MultiSearcherWraper:
 
 class MyTable(Table):
     def push_row(
-        self,
-        *renderables: Optional["RenderableType"],
-        style: Optional[StyleType] = None,
+            self,
+            *renderables: Optional["RenderableType"],
+            style: Optional[StyleType] = None,
     ) -> None:
         """向表格顶部插入行"""
 
@@ -152,13 +154,13 @@ class QuestionResolver:
     finish_flag: bool  # 答题完毕标志
 
     def __init__(
-        self,
-        exam_dto: QAQDtoBase,
-        fallback_save: bool = True,
-        fallback_fuzzer: bool = False,
-        persubmit_delay: float = 1.0,
-        auto_final_submit: bool = True,
-        cb_confirm_submit: Callable[[int, int, list, QAQDtoBase], bool] = None,
+            self,
+            exam_dto: QAQDtoBase,
+            fallback_save: bool = True,
+            fallback_fuzzer: bool = False,
+            persubmit_delay: float = 1.0,
+            auto_final_submit: bool = True,
+            cb_confirm_submit: Callable[[int, int, list, QAQDtoBase], bool] = None,
     ) -> None:
         """constructor
         Args:
@@ -392,10 +394,10 @@ class QuestionResolver:
             # 交卷确认不通过, 即退出工作流
             if self.cb_confirm_submit is not None:
                 if not self.cb_confirm_submit(
-                    self.completed_cnt,
-                    self.incompleted_cnt,
-                    self.mistakes,
-                    self.exam_dto,
+                        self.completed_cnt,
+                        self.incompleted_cnt,
+                        self.mistakes,
+                        self.exam_dto,
                 ):
                     return
 

--- a/resolver/question.py
+++ b/resolver/question.py
@@ -27,7 +27,8 @@ from logger import Logger
 from .searcher import MultiSearcherWraper, SearcherResp
 
 from .searcher.json import JsonFileSearcher
-from .searcher.restapi import CxSearcher, EnncySearcher, RestApiSearcher, TiKuHaiSearcher
+from .searcher.restapi import CxSearcher, EnncySearcher, RestApiSearcher, TiKuHaiSearcher, LyCk6Searcher, MukeSearcher, \
+    JsonApiSearcher
 from .searcher.sqlite import SqliteSearcher
 
 # 所有的搜索器类
@@ -38,6 +39,9 @@ SEARCHERS = {
     "RestApiSearcher": RestApiSearcher,
     "SqliteSearcher": SqliteSearcher,
     "TiKuHaiSearcher": TiKuHaiSearcher,
+    "LyCk6Searcher": LyCk6Searcher,
+    "MukeSearcher": MukeSearcher,
+    "JsonApiSearcher": JsonApiSearcher,
 }
 
 

--- a/resolver/searcher/restapi.py
+++ b/resolver/searcher/restapi.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 import jsonpath
 import requests
+from rich import json
 
 from cxapi.schema import QuestionModel
 
@@ -18,14 +19,14 @@ class RestApiSearcher(SearcherBase):
     method: Literal["GET", "POST"]
 
     def __init__(
-        self,
-        url,
-        q_field: str = "question",  # 题目文本字段
-        o_field: str | None = None, # 选项字段
-        a_field: str = "$.data",  # 答案字段 使用 jsonpath 语法
-        headers: dict | None = None,  # 自定义头部
-        ext_params: dict | None = None,  # 扩展请求字段
-        method: Literal["GET", "POST"] = "POST",  # 请求方式
+            self,
+            url,
+            q_field: str = "question",  # 题目文本字段
+            o_field: str | None = None,  # 选项字段
+            a_field: str = "$.data",  # 答案字段 使用 jsonpath 语法
+            headers: dict | None = None,  # 自定义头部
+            ext_params: dict | None = None,  # 扩展请求字段
+            method: Literal["GET", "POST"] = "POST",  # 请求方式
     ) -> None:
         self.session = requests.Session()
         self.url = url
@@ -82,13 +83,15 @@ class EnncySearcher(RestApiSearcher):
         if "".join(jsonpath.compile("$.data.answer").parse(json_content)) == "很抱歉, 题目搜索不到。":
             return SearcherResp(-404, "搜索失败", self, self.question_value, None)
         if "".join(jsonpath.compile("$.data.answer").parse(json_content)) in (
-            "配置为空或者配置错误，请自行检查或者联系作者查看。",
-            "题库配置的“凭证”被刷新，不要刷新你的凭证！只有当你的题库被别人盗用时才能进行刷新操作，否则会导致题库配置失效，请您前往 https://tk.enncy.cn/ 登录后到个人中心复制题库配置，并重新在脚本设置中粘贴题库配置。",
+                "配置为空或者配置错误，请自行检查或者联系作者查看。",
+                "题库配置的“凭证”被刷新，不要刷新你的凭证！只有当你的题库被别人盗用时才能进行刷新操作，否则会导致题库配置失效，请您前往 https://tk.enncy.cn/ "
+                "登录后到个人中心复制题库配置，并重新在脚本设置中粘贴题库配置。",
         ):
             return SearcherResp(-403, "Token无效", self, self.question_value, None)
         if result := self.rsp_query.parse(json_content):
             return SearcherResp(0, "ok", self, self.question_value, result[0])
         return SearcherResp(-500, "未匹配答案字段", self, self.question_value, None)
+
 
 class CxSearcher(RestApiSearcher):
     "网课小工具(Go题)题库搜索器"
@@ -113,4 +116,48 @@ class CxSearcher(RestApiSearcher):
             return SearcherResp(0, "ok", self, self.question_value, result[0])
         return SearcherResp(-500, "未匹配答案字段", self, self.question_value, None)
 
-__all__ = ["RestApiSearcher", "EnncySearcher", "CxSearcher"]
+
+class TiKuHaiSearcher(SearcherBase):
+    "题库海在线搜索器"
+    token: str
+
+    def __init__(
+            self,
+            token: str
+    ) -> None:
+        self.question = None
+        self.token = token
+        self.session = requests.Session()
+        self.url = "http://api.tikuhai.com/search"
+        self.session.headers.update(
+            {
+                "Host": "api.tikuhai.com",
+                "referer": "https://mooc1.chaoxing.com",
+                'Content-Type': 'application/json'
+            })
+        self.rsp_query = jsonpath.compile("$.data.answer")
+
+    def parse(self, json_content: dict | list) -> SearcherResp:
+        if jsonpath.compile("$.code").parse(json_content)[0] != 200:
+            return SearcherResp(-404, "搜索失败", self, self.question, None)
+        if result := self.rsp_query.parse(json_content):
+            return SearcherResp(0, "ok", self, self.question, result[0][0])
+        return SearcherResp(-500, "未匹配答案字段", self, self.question, None)
+
+    def invoke(self, question: QuestionModel) -> SearcherResp:
+        self.question = question.value
+        params = json.dumps({"question": question.value, "type": question.type.value,
+                             "id": question.id,
+                             "key": self.token})
+        try:
+            resp = self.session.post(
+                self.url,
+                data=params,
+            )
+            resp.raise_for_status()
+            return self.parse(resp.json())
+        except Exception as err:
+            return SearcherResp(-500, err.__str__(), self, self.question, None)
+
+
+__all__ = ["RestApiSearcher", "EnncySearcher", "CxSearcher", "TiKuHaiSearcher"]

--- a/resolver/searcher/restapi.py
+++ b/resolver/searcher/restapi.py
@@ -68,7 +68,7 @@ class RestApiSearcher(SearcherBase):
 
 
 class JsonApiSearcher(SearcherBase):
-    "REST API 在线搜索器"
+    "JSON API 在线搜索器"
     session: requests.Session
     q_field: str
     o_field: list[str] | None
@@ -119,8 +119,8 @@ class JsonApiSearcher(SearcherBase):
 
     def parse(self, json_content: dict | list) -> SearcherResp:
         if result := self.rsp_query.parse(json_content):
-            return SearcherResp(0, "ok", self, self.question_value, result[0])
-        return SearcherResp(-500, "未匹配答案字段", self, self.question_value, None)
+            return SearcherResp(0, "ok", self, self.question, result[0])
+        return SearcherResp(-500, "未匹配答案字段", self, self.question, None)
 
 
 class EnncySearcher(RestApiSearcher):
@@ -252,4 +252,5 @@ class LyCk6Searcher(JsonApiSearcher):
         return SearcherResp(-500, "未匹配答案字段", self, self.question, None)
 
 
-__all__ = ["RestApiSearcher", "EnncySearcher", "CxSearcher", "TiKuHaiSearcher", "MukeSearcher", "LyCk6Searcher"]
+__all__ = ["RestApiSearcher", "JsonApiSearcher", "EnncySearcher", "CxSearcher", "TiKuHaiSearcher", "MukeSearcher",
+           "LyCk6Searcher"]


### PR DESCRIPTION
```yaml
  # Json API 在线搜题
  # - type: JsonApiSearcher
  #   url: "http://10.50.9.10:8088/question/search"  # API URL 请进行替换
  #   q_field: "question"  # 题目参数名称
  #   o_field: null  # 选项参数名称 (可选)  填写为用`#`分隔数据, 用来进一步匹配答案 (格式：选项A#选项B#选项C) 不填为{"A":"xxx","B":"xxx","C":"xxx","D":"xxx"}
  #   headers:  # 自定义请求头 (可选) 使用 yaml 的 k-v 语法填写
  #     # eg: Authorization: 'xxx'
  #   ext_params: # 自定义扩展请求参数 (可选) 使用 yaml 的 k-v 语法填写
  #     # eg: Token: 'xxx'
  #   a_field: "$.data"  # 返回参数 使用 JSONPath 语法进行查询
```

