### PR TITLE
修复AttributeError: 'NoneType' object has no attribute 'group'问题，增加对题号后跟顿号的正则表达式匹配

### DIFF
--- a/cxapi/exam.py
+++ b/cxapi/exam.py
@@ -517,7 +517,7 @@ class ExamDto(QAQDtoBase):
         # 遍历父节点 (题型)
         for sheet_father_node in html.select("ul"):
             type_name = re.search(
-                r"[一二三四五六七八九]\. *(?P<type_name>\S+)",
+                r"[一二三四五六七八九]\.、 *(?P<type_name>\S+)",
                 sheet_father_node.select_one("h4.cardTit").text,
             ).group("type_name")
             # 遍历子节点 (题号+状态)


### PR DESCRIPTION
修复（或者说缓解？）issue中提到的AttributeError: 'NoneType' object has no attribute 'group'问题
原程序中只匹配“一.某某题”这种样式的题号，新增匹配“一、某某题”样式的题号